### PR TITLE
Fixed trim function and home path

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -195,7 +195,7 @@ const {dialog} = require('electron').remote;
           if (fileName !== undefined) {
         // handle files
         document.querySelector('#aeneaLinuxPath').innerText = fileName;
-        global.setOptionalPathToAeneasBinary(fileName.trim());
+        global.setOptionalPathToAeneasBinary(fileName[0].trim());
           }
       })
   }

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -26,11 +26,13 @@ var electronShell = require("electron").shell;
 var dataPath = currentWindow.dataPath.replace(/ /g,"\\ "); 
 var desktopPath = currentWindow.desktopPath;
 var appPath = currentWindow.appPath;
+var homePath = electron.remote.app.getPath('home');
 
 
 console.info("dataPath",dataPath);
 console.info("desktopPath",desktopPath);
 console.info("appPath",appPath);
+console.info("homePath",homePath);
 
 
 var selectFileBtnEl = document.getElementById('selectFileBtn');
@@ -150,13 +152,19 @@ createSubtitlesEl.onclick = function(){
 	// var  subtitlesComposer = require('../node_modules/subtitlescomposer');
 	var tmpOutputFilePath =  path.join(desktopPath, tmpOutputFileName);
 
+	fs.mkdir(homePath+"/tmp",function(err){
+	    if (!err) {
+			console.log("tmp directory created successfully!");
+		}
+	});
+
 	subtitlescomposer({
 		punctuationTextContent: getContentFromTextEditor(),
 		// the number of character per srt subtitle file line.
 		// TODO: add param to specify with default 
 		numberOfCharPerLine: getCharPerLineInput(),
 		// where to save intermediate segmented text file needed for aeneas module 
-		segmentedTextInput: appPath+"/src/tmp/segmentedtext.tmp.txt",
+		segmentedTextInput: homePath+"/tmp/segmentedtext.tmp.txt",
 		//audio or video file to use for aeneas alignement as original source 
 		mediaFile: sourceVideoPath,
 		outputCaptionFile: tmpOutputFilePath,


### PR DESCRIPTION
Hi,

Upon request of Michele Gianella I've made a couple of fixes in order to make the AppImage work well on Unix. I'm unsure if these problem were also on other platforms.

First change was that the `trim()` function was applied to an array an not to a String, this lead to the complete crash of the AppImage.

The second change is that, from my understanding, AppImage can't modify files that are not in the `home` of the user. 
So instead of creating the file in `appPath+"/src/tmp/segmentedtext.tmp.txt"`, the file is now created in `~/tmp/segmentedtext.tmp.txt`.

